### PR TITLE
Fusekiproxy

### DIFF
--- a/server/db/fuseki.js
+++ b/server/db/fuseki.js
@@ -78,7 +78,7 @@ class FusekiProxy {
             }
         }
 
-        return await new Promise((resolve, reject) => {
+        const data = await new Promise((resolve, reject) => {
             const req = http.request(options, (res) => {
                 if (res.statusCode < 200 || res.statusCode >= 300) {
                     logger.error(`SPARQL query ended with bad status code: ${res.statusCode}`);
@@ -91,7 +91,7 @@ class FusekiProxy {
                 res.on('end', () => {
                     const query_result = JSON.parse(data[0]);
                     logger.info('Finished SPARQL query');
-                    logger.debug(`Got SPARQL response: '${query_result}'`);
+                    logger.debug(`Got SPARQL response: '${JSON.stringify(query_result)}'`);
                     resolve(query_result);
                 });
             });
@@ -107,6 +107,11 @@ class FusekiProxy {
 
             req.end();
         });
+
+        return {
+            headers: data.head ? data.head.vars : [],
+            data: data.results ? data.results.bindings : []
+        }
     }
 }
 

--- a/server/db/fuseki.js
+++ b/server/db/fuseki.js
@@ -40,7 +40,7 @@ class FusekiProxy {
             const req = http.request(options, (res) => {
                 if (res.statusCode < 200 || res.statusCode >= 300) {
                     logger.error(`SPARQL query ended with bad status code: ${res.statusCode}`);
-                    reject(new Error('Fuseki Error'));
+                    resolve(false);
                 }
                 else{
                     resolve(true);

--- a/server/tests/db.fuseki.test.js
+++ b/server/tests/db.fuseki.test.js
@@ -52,18 +52,18 @@ test('Write and read to Fuseki database', async () => {
         const read_result = await fuseki.read_data(read_test);
         console.log(read_result)
         expect(read_result).toBeTruthy();
-        expect(read_result.results).toBeTruthy();
-        expect(read_result.results.bindings).toBeTruthy();
-        expect(read_result.results.bindings[0].name).toBeTruthy();
-        expect(read_result.results.bindings[0].schoolName).toBeTruthy();
-        expect(read_result.results.bindings[0].name.value).toBe("Joe Bruin");
-        expect(read_result.results.bindings[0].schoolName.value).toBe("University of California - Los Angeles");
+        expect(read_result.headers).toStrictEqual(["name", "schoolName"]);
+        expect(read_result.data).toBeTruthy();
+        expect(read_result.data[0].name).toBeTruthy();
+        expect(read_result.data[0].schoolName).toBeTruthy();
+        expect(read_result.data[0].name.value).toBe("Joe Bruin");
+        expect(read_result.data[0].schoolName.value).toBe("University of California - Los Angeles");
     } finally {
         const delete_result = await fuseki.write_data(delete_test);
         expect(delete_result).toBeTruthy();
         const read_result = await fuseki.read_data(read_test);
         expect(read_result).toBeTruthy();
-        expect(read_result.results).toBeTruthy();
-        expect(read_result.results.bindings).toStrictEqual([]);
+        expect(read_result.headers).toStrictEqual(["name", "schoolName"]);
+        expect(read_result.data).toStrictEqual([]);
     }
 });

--- a/server/tests/db.fuseki.test.js
+++ b/server/tests/db.fuseki.test.js
@@ -10,3 +10,60 @@ test('Fuseki database connection', async () => {
     const connection = await fuseki.test_connection();
     expect(connection).toBe(true);
 });
+
+test('Write and read to Fuseki database', async () => {
+    const write_test = `
+        PREFIX eql: <http://excql.org/relations/#>
+        INSERT DATA
+        {
+            <http://students/JoeBruin>
+                eql:name "Joe Bruin";
+                eql:school <http://schools/UCLA> .
+            <http://schools/UCLA>
+                eql:name "University of California - Los Angeles" .
+        }
+    `;
+    const read_test = `
+        PREFIX eql: <http://excql.org/relations/#>
+        SELECT ?name ?schoolName
+        WHERE {
+            ?student eql:school ?school.
+            ?student eql:name ?name.
+            ?school eql:name ?schoolName.
+            FILTER (?name="Joe Bruin").
+        }
+        LIMIT 1
+    `;
+    const delete_test = `
+        PREFIX eql: <http://excql.org/relations/#>
+        DELETE DATA
+        {
+            <http://students/JoeBruin>
+                eql:name "Joe Bruin";
+                eql:school <http://schools/UCLA> .
+            <http://schools/UCLA>
+                eql:name "University of California - Los Angeles" .
+        }
+    `;
+
+    try {
+        const write_result = await fuseki.write_data(write_test);
+        expect(write_result).toBe(true);
+        const read_result = await fuseki.read_data(read_test);
+        console.log(read_result)
+        expect(read_result).toBeTruthy();
+        expect(read_result.results).toBeTruthy();
+        expect(read_result.results.bindings).toBeTruthy();
+        expect(read_result.results.bindings[0].name).toBeTruthy();
+        expect(read_result.results.bindings[0].schoolName).toBeTruthy();
+        expect(read_result.results.bindings[0].name.value).toBe("Joe Bruin");
+        expect(read_result.results.bindings[0].schoolName.value).toBe("University of California - Los Angeles");
+    } finally {
+        const delete_result = await fuseki.write_data(delete_test);
+        expect(delete_result).toBeTruthy();
+        const read_result = await fuseki.read_data(read_test);
+        expect(read_result).toBeTruthy();
+        expect(read_result.results).toBeTruthy();
+        expect(read_result.results.bindings).toStrictEqual([]);
+    }
+});

--- a/server/tests/db.fuseki.test.js
+++ b/server/tests/db.fuseki.test.js
@@ -48,9 +48,10 @@ test('Write and read to Fuseki database', async () => {
 
     try {
         const write_result = await fuseki.write_data(write_test);
-        expect(write_result).toBe(true);
+        expect(write_result.error).toBeFalsy();
+        expect(write_result.results).toBe(true);
         const read_result = await fuseki.read_data(read_test);
-        expect(read_result).toBeTruthy();
+        expect(read_result.error).toBeFalsy();
         expect(read_result.headers).toStrictEqual(["name", "schoolName"]);
         expect(read_result.data).toBeTruthy();
         expect(read_result.data[0].name).toBeTruthy();
@@ -59,9 +60,10 @@ test('Write and read to Fuseki database', async () => {
         expect(read_result.data[0].schoolName.value).toBe("University of California - Los Angeles");
     } finally {
         const delete_result = await fuseki.write_data(delete_test);
-        expect(delete_result).toBeTruthy();
+        expect(delete_result.error).toBeFalsy();
+        expect(delete_result.results).toBe(true);
         const read_result = await fuseki.read_data(read_test);
-        expect(read_result).toBeTruthy();
+        expect(read_result.error).toBeFalsy();
         expect(read_result.headers).toStrictEqual(["name", "schoolName"]);
         expect(read_result.data).toStrictEqual([]);
     }
@@ -105,12 +107,65 @@ test('Write query with bad syntax returns false and no change', async () => {
 
     try {
         const write_result = await fuseki.write_data(write_test);
-        expect(write_result).toBe(false);
+        expect(write_result.error).toBeTruthy();
+        expect(write_result.results).toBe(false);
         const read_result = await fuseki.read_data(read_test);
-        expect(read_result).toBeTruthy();
+        expect(read_result.error).toBeFalsy();
         expect(read_result.data).toStrictEqual([]);
+        expect(read_result.headers).toStrictEqual(["name", "schoolName"]);
     } finally {
         const delete_result = await fuseki.write_data(delete_test);
-        expect(delete_result).toBe(true);
+        expect(delete_result.error).toBeFalsy(); // When nothing to delete, no error
+        expect(delete_result.results).toBe(true);
+    }
+});
+
+test('Read query with bad syntax returns error', async () => {
+    const write_test = `
+        PREFIX eql: <http://excql.org/relations/#>
+        INSERT DATA
+        {
+            <http://students/TracyZhao>
+                eql:name "Tracy Zhao";
+                eql:school <http://schools/UCLA> .
+            <http://schools/UCLA>
+                eql:name "University of California - Los Angeles" .
+        }
+    `;
+    const read_test = `
+        PREFIX eql: <http://excql.org/relations/#>
+        SELECT ?name ?schoolName
+        WHERE {
+            ?student eql:school ?school
+            ?student eql:name ?name
+            ?school eql:name ?schoolName
+            FILTER (?name="Tracy Zhao")
+        }
+        LIMIT 1
+    `;
+    const delete_test = `
+        PREFIX eql: <http://excql.org/relations/#>
+        DELETE DATA
+        {
+            <http://students/TracyZhao>
+                eql:name "Tracy Zhao";
+                eql:school <http://schools/UCLA> .
+            <http://schools/UCLA>
+                eql:name "University of California - Los Angeles" .
+        }
+    `;
+    
+    try {
+        const write_result = await fuseki.write_data(write_test);
+        expect(write_result.error).toBeFalsy();
+        expect(write_result.results).toBe(true);
+        const read_result = await fuseki.read_data(read_test);
+        expect(read_result.error).toBeTruthy();
+        expect(read_result.data).toStrictEqual([]);
+        expect(read_result.headers).toStrictEqual([]);
+    } finally {
+        const delete_result = await fuseki.write_data(delete_test);
+        expect(delete_result.error).toBeFalsy();
+        expect(delete_result.results).toBe(true);
     }
 });


### PR DESCRIPTION
- Added Fuseki Proxy Class
- Can send a read SPARQL query to the Fuseki database
- Can process the results of the query
- Can send a write SPARQL query to the Fuseki database
- Write query returns true if successful
- Added some tests for the above